### PR TITLE
Constrain PHPDocumentor

### DIFF
--- a/php/docker/composer.json
+++ b/php/docker/composer.json
@@ -3,7 +3,7 @@
     "colinmollenhour/modman": "~1.11",
     "composer/composer": "~1.0@dev",
     "n98/magerun": "~1.9",
-    "phpdocumentor/phpdocumentor": "~2.8",
+    "phpdocumentor/phpdocumentor": "2.9.0",
     "phploc/phploc": "~2.1",
     "phpmd/phpmd": "~2.2",
     "phpunit/phpunit": "~4.6",


### PR DESCRIPTION
Abandoned repo created an error - I fixed by constraining PHPDocumentor to v2.9.0 but there may be a better way..