### PR TITLE
Constrain PHP to 7.0

### DIFF
--- a/php/docker/Dockerfile
+++ b/php/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-fpm
+FROM php:7.0-fpm
 
 RUN apt-get update && apt-get install -y \
     libfreetype6-dev \


### PR DESCRIPTION
Magento 2.1 only lists PHP compatibility up to 7.0 and the 7-fpm was downloading 7.2 which had a whole host of issues.

Magento 2.2 I *think* has issues with 7.2 but is compatible with 7.1 just for future reference..